### PR TITLE
Fix Steam review cursor parameter encoding

### DIFF
--- a/steam_reviews.py
+++ b/steam_reviews.py
@@ -8,7 +8,6 @@ import sys
 import time
 from dataclasses import dataclass
 from typing import Iterable, List, Optional
-from urllib.parse import quote_plus
 
 import requests
 from requests import Response
@@ -116,7 +115,7 @@ class SteamReviewExtractor:
         params = dict(DEFAULT_REQUEST_PARAMS)
         params.update({
             "language": self.language,
-            "cursor": quote_plus(cursor),
+            "cursor": cursor,
         })
 
         for attempt in range(1, self.retries + 1):


### PR DESCRIPTION
## Summary
- stop double-encoding the Steam API cursor by removing quote_plus
- rely on requests to encode the cursor parameter correctly so pagination works

## Testing
- python -m compileall steam_reviews.py

------
https://chatgpt.com/codex/tasks/task_e_68cc708b40fc832eb709ba001172205c