### PR TITLE
Add language-aware topic density verification

### DIFF
--- a/steam_agent/agent/__init__.py
+++ b/steam_agent/agent/__init__.py
@@ -1,0 +1,5 @@
+"""Core agent runtime helpers."""
+
+from . import loop, verifiers
+
+__all__ = ["loop", "verifiers"]

--- a/steam_agent/agent/loop.py
+++ b/steam_agent/agent/loop.py
@@ -1,0 +1,153 @@
+"""Pipeline orchestration utilities for the Steam agent."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from typing import Any, Dict, Tuple
+
+from ..pipeline import report as report_module
+from . import verifiers
+
+__all__ = ["run_pipeline"]
+
+
+def _ensure_mapping(value: Mapping[str, Any] | None) -> Dict[str, Any]:
+    if value is None:
+        return {}
+    return dict(value)
+
+
+def _normalize_lang_counts(raw: Mapping[str, Any] | None) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    if raw:
+        for key, value in raw.items():
+            try:
+                counts[str(key)] = int(value)
+            except (TypeError, ValueError):
+                continue
+    return counts
+
+
+def _call_with_metrics(
+    fn: Callable[..., Mapping[str, Any] | Tuple[Any, Mapping[str, Any]]],
+    kwargs: Mapping[str, Any] | None = None,
+) -> Tuple[Any | None, Dict[str, Any]]:
+    call_kwargs = dict(kwargs or {})
+    result = fn(**call_kwargs)
+
+    if isinstance(result, tuple) and len(result) == 2 and isinstance(result[1], Mapping):
+        payload, metrics = result
+    elif isinstance(result, Mapping):
+        payload, metrics = None, result
+    else:
+        raise TypeError("Callable is expected to return a mapping of metrics or (payload, metrics).")
+
+    return payload, _ensure_mapping(metrics)
+
+
+def run_pipeline(
+    prepare_fn: Callable[..., Mapping[str, Any] | Tuple[Any, Mapping[str, Any]]],
+    classify_fn: Callable[..., Mapping[str, Any] | Tuple[Any, Mapping[str, Any]]],
+    *,
+    min_conf: float,
+    logger: logging.Logger | None = None,
+    supported_langs: set[str] | None = None,
+    target_supported_rate: float = 0.70,
+    max_abs_slack: float = 0.20,
+    min_rows_for_strict: int = 500,
+    threshold_floor: float = 0.35,
+    threshold_step: float = 0.05,
+    prepare_kwargs: Mapping[str, Any] | None = None,
+    classify_kwargs: Mapping[str, Any] | None = None,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Execute the prepare + classify steps with dynamic topic-density checks."""
+
+    logger = logger or logging.getLogger(__name__)
+    supported_langs = supported_langs or {"en"}
+
+    prepare_payload, prepare_metrics = _call_with_metrics(prepare_fn, prepare_kwargs)
+
+    lang_counts = _normalize_lang_counts(prepare_metrics.get("lang_counts"))
+    total_rows = prepare_metrics.get("rows_in")
+
+    classify_kwargs = dict(classify_kwargs or {})
+    classify_kwargs["min_conf"] = min_conf
+
+    classify_payload, classify_metrics = _call_with_metrics(classify_fn, classify_kwargs)
+
+    blank_pct = classify_metrics.get("blank_pct")
+    if blank_pct is None:
+        raise KeyError("Classification metrics must include 'blank_pct'.")
+
+    ok, density_info = verifiers.verify_topic_density(
+        blank_pct=float(blank_pct),
+        lang_counts=lang_counts,
+        supported_langs=supported_langs,
+        target_supported_rate=target_supported_rate,
+        max_abs_slack=max_abs_slack,
+        min_rows_for_strict=min_rows_for_strict,
+        total_rows=total_rows,
+    )
+
+    current_min_conf = min_conf
+
+    if not ok:
+        logger.info(
+            "Topic coverage %.1f%% below expectation (~%.1f%%). Attempting to lower min_conf.",
+            (density_info["actual_labeled"] * 100.0),
+            (density_info["expected_overall"] * 100.0),
+        )
+        new_min_conf = max(current_min_conf - threshold_step, threshold_floor)
+        if new_min_conf < current_min_conf:
+            classify_kwargs["min_conf"] = new_min_conf
+            classify_payload, classify_metrics = _call_with_metrics(classify_fn, classify_kwargs)
+            blank_pct = classify_metrics.get("blank_pct")
+            if blank_pct is None:
+                raise KeyError("Classification metrics must include 'blank_pct' after retry.")
+
+            ok, density_info = verifiers.verify_topic_density(
+                blank_pct=float(blank_pct),
+                lang_counts=lang_counts,
+                supported_langs=supported_langs,
+                target_supported_rate=target_supported_rate,
+                max_abs_slack=max_abs_slack,
+                min_rows_for_strict=min_rows_for_strict,
+                total_rows=total_rows,
+            )
+            current_min_conf = new_min_conf
+        else:
+            logger.debug("min_conf already at floor %.2f; skipping retry.", threshold_floor)
+
+    if not ok:
+        supported_share = density_info.get("supported_share", 0.0) or 0.0
+        strict = bool(density_info.get("strict", False))
+        if supported_share < 0.15 or not strict:
+            logger.warning(
+                "Topic coverage %.1f%% remains below expectation (~%.1f%%) but continuing due to "
+                "supported-language share %.1f%% and strict=%s.",
+                density_info["actual_labeled"] * 100.0,
+                density_info["expected_overall"] * 100.0,
+                supported_share * 100.0,
+                strict,
+            )
+        else:
+            raise RuntimeError(
+                "Topic density verification failed despite sufficient supported-language share."
+            )
+
+    footer = report_module.render_topic_density_footer(lang_counts, density_info)
+
+    outputs = {
+        "prepare": prepare_payload,
+        "classify": classify_payload,
+    }
+    metrics = {
+        "prepare": prepare_metrics,
+        "classify": classify_metrics,
+        "topic_density": density_info,
+        "min_conf": current_min_conf,
+        "footer": footer,
+    }
+
+    return outputs, metrics

--- a/steam_agent/agent/verifiers.py
+++ b/steam_agent/agent/verifiers.py
@@ -1,0 +1,78 @@
+"""Validation helpers for the Steam agent pipeline."""
+
+from __future__ import annotations
+
+from typing import Dict, Mapping, Set, Tuple
+
+
+def verify_topic_density(
+    blank_pct: float,
+    lang_counts: Mapping[str, int] | None,
+    supported_langs: Set[str] | None = None,
+    target_supported_rate: float = 0.70,
+    max_abs_slack: float = 0.20,
+    min_rows_for_strict: int = 500,
+    total_rows: int | None = None,
+) -> Tuple[bool, Dict[str, float | bool]]:
+    """Evaluate whether the topic density is acceptable.
+
+    Parameters
+    ----------
+    blank_pct:
+        Share of rows that received no topic label from classification.
+    lang_counts:
+        Mapping of language code to row counts observed during prepare.
+    supported_langs:
+        Languages supported by the taxonomy. Defaults to ``{"en"}``.
+    target_supported_rate:
+        Expected label rate for supported languages. Defaults to 70%.
+    max_abs_slack:
+        Absolute slack permitted before flagging as a failure.
+    min_rows_for_strict:
+        Number of rows required before applying the strict threshold.
+    total_rows:
+        Optional total row count; falls back to the sum of ``lang_counts``.
+
+    Returns
+    -------
+    tuple
+        ``(passed, info)`` where ``info`` provides context for reporting.
+    """
+
+    if lang_counts is None:
+        lang_counts = {}
+
+    supported_langs = supported_langs or {"en"}
+
+    total = int(sum(lang_counts.values()))
+    if total <= 0:
+        total = 1
+
+    supported = int(sum(lang_counts.get(lang, 0) for lang in supported_langs))
+    supported_share = supported / total
+
+    actual_labeled = max(0.0, min(1.0, 1.0 - float(blank_pct or 0.0)))
+    expected_overall = supported_share * float(target_supported_rate)
+
+    total_for_strict = total_rows if total_rows is not None else total
+    strict = (total_for_strict or 0) >= int(min_rows_for_strict)
+
+    if strict:
+        threshold = expected_overall - float(max_abs_slack)
+    else:
+        threshold = expected_overall - (float(max_abs_slack) + 0.10)
+    threshold = max(0.0, threshold)
+
+    passed = actual_labeled >= threshold
+
+    info: Dict[str, float | bool] = {
+        "supported_share": supported_share,
+        "expected_overall": expected_overall,
+        "actual_labeled": actual_labeled,
+        "strict": strict,
+    }
+
+    return passed, info
+
+
+__all__ = ["verify_topic_density"]

--- a/steam_agent/pipeline/__init__.py
+++ b/steam_agent/pipeline/__init__.py
@@ -1,0 +1,5 @@
+"""Pipeline helpers for the Steam agent."""
+
+from . import report
+
+__all__ = ["report"]

--- a/steam_agent/pipeline/report.py
+++ b/steam_agent/pipeline/report.py
@@ -1,0 +1,49 @@
+"""Reporting helpers for the Steam agent pipeline."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+
+def _format_language_mix(lang_counts: Mapping[str, int]) -> str:
+    total = sum(int(count) for count in lang_counts.values())
+    if total <= 0:
+        return "Language mix: (none)"
+
+    parts: list[str] = []
+    for lang, raw_count in sorted(lang_counts.items(), key=lambda kv: (-int(kv[1]), kv[0])):
+        count = int(raw_count)
+        share = count / total
+        parts.append(f"{lang}: {share:.1%} ({count})")
+    return "Language mix: " + ", ".join(parts)
+
+
+def render_topic_density_footer(
+    lang_counts: Mapping[str, int] | None,
+    density_info: Mapping[str, float | bool] | None,
+) -> str:
+    """Return a footer block describing language mix and coverage expectations."""
+
+    lang_counts = lang_counts or {}
+    density_info = density_info or {}
+
+    lines: list[str] = []
+    lines.append(_format_language_mix(lang_counts))
+
+    supported_share = float(density_info.get("supported_share", 0.0) or 0.0)
+    lines.append(f"Supported-language share: {supported_share:.1%}")
+
+    actual = float(density_info.get("actual_labeled", 0.0) or 0.0)
+    expected = float(density_info.get("expected_overall", 0.0) or 0.0)
+    lines.append(
+        "Coverage: {actual:.1%} overall (expected ~{expected:.1%} based on {supported:.1%} supported-language share).".format(
+            actual=actual,
+            expected=expected,
+            supported=supported_share,
+        )
+    )
+
+    return "\n".join(lines)
+
+
+__all__ = ["render_topic_density_footer"]


### PR DESCRIPTION
## Summary
- add a verifier that scales topic-density expectations to the supported-language share
- update the agent loop to retry classification with a lower min_conf when coverage is low and surface the new footer data
- extend the pipeline report footer with language mix, supported-language share, and expected vs. actual coverage messaging

## Testing
- python -m compileall steam_agent

------
https://chatgpt.com/codex/tasks/task_e_68e2ebcc72ec832ea574f47643c7f740